### PR TITLE
Remove binary icons from extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
-# paywall-to-reader
+# Paywall to Reader
+
+This project contains a simple Chrome extension that archives a web page using [Archive.is](https://archive.is) and then saves the archived version to your Readwise Reader reading list.
+
+## Features
+
+- Extension button opens a popup where you can enter a URL (pre-filled with the current tab).
+- Retrieves the latest archived version of the URL from `https://archive.is/newest/<url>`.
+- Adds the archived link to Readwise Reader using the Reader API.
+- Stores your Readwise API token using Chrome's `storage.sync`.
+
+## Installing
+
+1. Open Chrome and navigate to `chrome://extensions`.
+2. Enable **Developer mode**.
+3. Click **Load unpacked** and select the `extension` folder in this repository.
+4. Open the extension options page and enter your Readwise Reader API token.
+
+## Usage
+
+1. Browse to any article or provide a URL in the popup.
+2. Click **Archive & Save**.
+3. The extension fetches the latest archive snapshot and sends it to Readwise Reader.
+
+## Notes
+
+- The extension uses the endpoint `https://archive.is/newest/<url>` to resolve the most recent snapshot. Archive.is may block automated requests or require additional headers; in practice you might need to adjust the request or use a different Archive.today domain (such as archive.ph).
+- The Readwise Reader API endpoint used is `https://readwise.io/api/v3/save/`. Provide your token on the options page.
+- The repository omits icon files so the extension will display the default Chrome icon.
+

--- a/extension/background.js
+++ b/extension/background.js
@@ -1,0 +1,41 @@
+async function fetchArchiveUrl(url) {
+  const response = await fetch(`https://archive.is/newest/${encodeURIComponent(url)}`, {
+    redirect: 'follow'
+  });
+  return response.url; // final redirected url is the snapshot
+}
+
+async function saveToReadwise(snapshotUrl, token) {
+  const resp = await fetch('https://readwise.io/api/v3/save/', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Token ${token}`
+    },
+    body: JSON.stringify({ url: snapshotUrl })
+  });
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(`Readwise error: ${resp.status} ${text}`);
+  }
+}
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.type === 'archive_and_save') {
+    chrome.storage.sync.get(['readwiseToken'], async ({ readwiseToken }) => {
+      if (!readwiseToken) {
+        sendResponse({ error: 'No Readwise token set' });
+        return;
+      }
+      try {
+        const snapshotUrl = await fetchArchiveUrl(message.url);
+        await saveToReadwise(snapshotUrl, readwiseToken);
+        sendResponse({ success: true, snapshot: snapshotUrl });
+      } catch (err) {
+        sendResponse({ error: err.message });
+      }
+    });
+    // Indicate we'll send a response asynchronously
+    return true;
+  }
+});

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,22 @@
+{
+  "manifest_version": 3,
+  "name": "Paywall to Reader",
+  "description": "Archive a page and save it to Readwise Reader",
+  "version": "1.0",
+  "action": {
+    "default_popup": "popup.html"
+  },
+  "permissions": [
+    "storage",
+    "activeTab"
+  ],
+  "host_permissions": [
+    "https://archive.is/*",
+    "https://archive.ph/*",
+    "https://readwise.io/*"
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "options_page": "options.html"
+}

--- a/extension/options.html
+++ b/extension/options.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Paywall to Reader Options</title>
+  <style>
+    body { font-family: sans-serif; margin: 20px; }
+  </style>
+</head>
+<body>
+  <h1>Paywall to Reader Options</h1>
+  <label>
+    Readwise Reader API Token:
+    <input type="password" id="token" style="width: 400px;" />
+  </label>
+  <button id="save">Save</button>
+  <p id="status"></p>
+
+  <script src="options.js"></script>
+</body>
+</html>

--- a/extension/options.js
+++ b/extension/options.js
@@ -1,0 +1,15 @@
+document.getElementById('save').addEventListener('click', () => {
+  const token = document.getElementById('token').value.trim();
+  chrome.storage.sync.set({ readwiseToken: token }, () => {
+    const status = document.getElementById('status');
+    status.textContent = 'Saved!';
+    setTimeout(() => status.textContent = '', 2000);
+  });
+});
+
+// Load saved token
+chrome.storage.sync.get(['readwiseToken'], ({ readwiseToken }) => {
+  if (readwiseToken) {
+    document.getElementById('token').value = readwiseToken;
+  }
+});

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Paywall to Reader</title>
+  <style>
+    body { font-family: sans-serif; width: 300px; padding: 10px; }
+    #status { margin-top: 10px; }
+  </style>
+</head>
+<body>
+  <input type="text" id="url" placeholder="URL" style="width: 100%;" />
+  <button id="archive">Archive & Save</button>
+  <div id="status"></div>
+
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,0 +1,21 @@
+function $(id) { return document.getElementById(id); }
+
+// Prefill URL with current tab
+chrome.tabs.query({ active: true, currentWindow: true }, tabs => {
+  if (tabs[0] && tabs[0].url) {
+    $('#url').value = tabs[0].url;
+  }
+});
+
+$('#archive').addEventListener('click', () => {
+  const url = $('#url').value.trim();
+  if (!url) return;
+  $('#status').textContent = 'Archiving...';
+  chrome.runtime.sendMessage({ type: 'archive_and_save', url }, response => {
+    if (response && response.success) {
+      $('#status').textContent = 'Saved to Reader!';
+    } else {
+      $('#status').textContent = 'Error: ' + (response && response.error);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- remove PNG icon files that caused PR creation errors
- update manifest to remove icon references
- note in README that the extension uses the default Chrome icon

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_684485fc1bbc8323944ddedf1491c0f9