### PR TITLE
Strip query params before archiving

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -2,6 +2,8 @@ chrome.action.onClicked.addListener(tab => {
   if (!tab || !tab.url) {
     return;
   }
-  const archiveUrl = `https://archive.ph/newest/${encodeURIComponent(tab.url)}`;
+  const urlObj = new URL(tab.url);
+  const baseUrl = `${urlObj.origin}${urlObj.pathname}`;
+  const archiveUrl = `https://archive.ph/newest/${encodeURIComponent(baseUrl)}`;
   chrome.tabs.update(tab.id, { url: archiveUrl });
 });


### PR DESCRIPTION
## Summary
- only send the base URL to archive.ph

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6867c81e150c8323a0b5aca84886fdea